### PR TITLE
feat: Add weekly SBOM workflow

### DIFF
--- a/.github/workflows/fetch-sbom.yml
+++ b/.github/workflows/fetch-sbom.yml
@@ -14,30 +14,42 @@ permissions:
 jobs:
   fetch-sbom:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Get latest release version for care repo
+        id: care_version
+        run: |
+          VERSION=$(curl -s https://api.github.com/repos/ohcnetwork/care/releases/latest | jq -r .tag_name)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+      - name: Get latest release version for care_fe repo
+        id: care_fe_version
+        run: |
+          VERSION=$(curl -s https://api.github.com/repos/ohcnetwork/care_fe/releases/latest | jq -r .tag_name)
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+
       - name: Create SBOM directories
         run: |
-          mkdir -p care/v3.0.0
-          mkdir -p care_fe/v3.0.0
+          mkdir -p care/${{ env.VERSION }}
+          mkdir -p care_fe/${{ env.VERSION }}
 
       - name: Fetch SBOM data
         run: |
           curl -H "Accept: application/vnd.github+json" \
                -H "X-GitHub-Api-Version: 2022-11-28" \
-               https://api.github.com/repos/ohcnetwork/care/dependency-graph/sbom > care/v3.0.0/sbom.json
+               https://api.github.com/repos/ohcnetwork/care/dependency-graph/sbom > care/${{ env.VERSION }}/sbom.json
 
           curl -H "Accept: application/vnd.github+json" \
                -H "X-GitHub-Api-Version: 2022-11-28" \
-               https://api.github.com/repos/ohcnetwork/care_fe/dependency-graph/sbom > care_fe/v3.0.0/sbom.json
+               https://api.github.com/repos/ohcnetwork/care_fe/dependency-graph/sbom > care_fe/${{ env.VERSION }}/sbom.json
 
       - name: Commit and push changes
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
           git add .
-          git commit -m "Update SBOM data" || exit 0
+          git commit -m "Update SBOM data for version ${{ env.VERSION }}" || exit 0
           git push || exit 0

--- a/.github/workflows/fetch-sbom.yml
+++ b/.github/workflows/fetch-sbom.yml
@@ -1,0 +1,43 @@
+name: Weekly SBOM Update
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Runs every Sunday at midnight IST (UTC+5:30)
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  fetch-sbom:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Create SBOM directories
+        run: |
+          mkdir -p care/V3
+          mkdir -p care_fe/V3
+
+      - name: Fetch SBOM data
+        run: |
+          curl -H "Accept: application/vnd.github+json" \
+               -H "X-GitHub-Api-Version: 2022-11-28" \
+               https://api.github.com/repos/ohcnetwork/care_fe/dependency-graph/sbom > care_fe/V3/sbom.json
+
+          curl -H "Accept: application/vnd.github+json" \
+               -H "X-GitHub-Api-Version: 2022-11-28" \
+               https://api.github.com/repos/ohcnetwork/care/dependency-graph/sbom > care/V3/sbom.json
+
+      - name: Commit and push changes
+        run: |
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
+          git add .
+          git commit -m "Update SBOM data" || echo "No changes to commit"
+          git push || echo "No changes to push"

--- a/.github/workflows/fetch-sbom.yml
+++ b/.github/workflows/fetch-sbom.yml
@@ -2,7 +2,7 @@ name: Weekly SBOM Update
 
 on:
   schedule:
-    - cron: '0 0 * * 0' # Runs every Sunday at midnight IST (UTC+5:30)
+    - cron: '30 18 * * 6' # Runs every Sunday at midnight IST (18:30 UTC on Saturdays)
   workflow_dispatch:
   push:
     branches:
@@ -49,7 +49,7 @@ jobs:
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
-          git add .
+          git add . 
           git diff --exit-code || git commit -m "Update SBOM data for version ${{ env.VERSION }}"
           git push || exit 0
 
@@ -62,5 +62,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./
+          publish_dir: ./ 
           publish_branch: care-sbom

--- a/.github/workflows/fetch-sbom.yml
+++ b/.github/workflows/fetch-sbom.yml
@@ -32,27 +32,25 @@ jobs:
           VERSION=$(curl -s https://api.github.com/repos/ohcnetwork/care_fe/releases/latest | jq -r .tag_name)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
-      - name: Create SBOM directories
+      - name: Check and create SBOM directories for care and care_fe
         run: |
-          mkdir -p care/${{ env.VERSION }}
-          mkdir -p care_fe/${{ env.VERSION }}
-
-      - name: Fetch SBOM data
-        run: |
-          curl -H "Accept: application/vnd.github+json" \
-               -H "X-GitHub-Api-Version: 2022-11-28" \
-               https://api.github.com/repos/ohcnetwork/care/dependency-graph/sbom > care/${{ env.VERSION }}/sbom.json
-
-          curl -H "Accept: application/vnd.github+json" \
-               -H "X-GitHub-Api-Version: 2022-11-28" \
-               https://api.github.com/repos/ohcnetwork/care_fe/dependency-graph/sbom > care_fe/${{ env.VERSION }}/sbom.json
+          for repo in "care" "care_fe"; do
+            if [ ! -d "$repo/${{ env.VERSION }}" ]; then
+              mkdir -p $repo/${{ env.VERSION }}
+              curl -H "Accept: application/vnd.github+json" \
+                   -H "X-GitHub-Api-Version: 2022-11-28" \
+                   https://api.github.com/repos/ohcnetwork/$repo/dependency-graph/sbom > $repo/${{ env.VERSION }}/sbom.json
+            else
+              echo "$repo/${{ env.VERSION }} already exists. Skipping SBOM fetch for $repo."
+            fi
+          done
 
       - name: Commit and push changes
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
           git add .
-          git commit -m "Update SBOM data for version ${{ env.VERSION }}" || exit 0
+          git diff --exit-code || git commit -m "Update SBOM data for version ${{ env.VERSION }}"
           git push || exit 0
 
   deploy-sbom:

--- a/.github/workflows/fetch-sbom.yml
+++ b/.github/workflows/fetch-sbom.yml
@@ -27,12 +27,8 @@ jobs:
 
       - name: Create SBOM directories for care and care_fe (if not exists)
         run: |
-          if [ ! -d "care/${{ env.CARE_VERSION }}" ]; then
-            mkdir -p care/${{ env.CARE_VERSION }}
-          fi
-          if [ ! -d "care_fe/${{ env.CARE_FE_VERSION }}" ]; then
-            mkdir -p care_fe/${{ env.CARE_FE_VERSION }}
-          fi
+          mkdir -p care/${{ env.CARE_VERSION }}
+          mkdir -p care_fe/${{ env.CARE_FE_VERSION }}
 
       - name: Fetch SBOM data for care and care_fe (if not exists)
         run: |

--- a/.github/workflows/fetch-sbom.yml
+++ b/.github/workflows/fetch-sbom.yml
@@ -3,10 +3,10 @@ name: Weekly SBOM Update
 on:
   schedule:
     - cron: '0 0 * * 0' # Runs every Sunday at midnight IST (UTC+5:30)
+  workflow_dispatch:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -21,23 +21,23 @@ jobs:
 
       - name: Create SBOM directories
         run: |
-          mkdir -p care/V3
-          mkdir -p care_fe/V3
+          mkdir -p care/v3.0.0
+          mkdir -p care_fe/v3.0.0
 
       - name: Fetch SBOM data
         run: |
           curl -H "Accept: application/vnd.github+json" \
                -H "X-GitHub-Api-Version: 2022-11-28" \
-               https://api.github.com/repos/ohcnetwork/care_fe/dependency-graph/sbom > care_fe/V3/sbom.json
+               https://api.github.com/repos/ohcnetwork/care/dependency-graph/sbom > care/v3.0.0/sbom.json
 
           curl -H "Accept: application/vnd.github+json" \
                -H "X-GitHub-Api-Version: 2022-11-28" \
-               https://api.github.com/repos/ohcnetwork/care/dependency-graph/sbom > care/V3/sbom.json
+               https://api.github.com/repos/ohcnetwork/care_fe/dependency-graph/sbom > care_fe/v3.0.0/sbom.json
 
       - name: Commit and push changes
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
           git add .
-          git commit -m "Update SBOM data" || echo "No changes to commit"
-          git push || echo "No changes to push"
+          git commit -m "Update SBOM data" || exit 0
+          git push || exit 0

--- a/.github/workflows/fetch-sbom.yml
+++ b/.github/workflows/fetch-sbom.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  pages: write
 
 jobs:
   fetch-sbom:
@@ -53,3 +54,15 @@ jobs:
           git add .
           git commit -m "Update SBOM data for version ${{ env.VERSION }}" || exit 0
           git push || exit 0
+
+  deploy-sbom:
+    runs-on: ubuntu-latest
+    needs: fetch-sbom
+
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./
+          publish_branch: main

--- a/.github/workflows/fetch-sbom.yml
+++ b/.github/workflows/fetch-sbom.yml
@@ -73,4 +73,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./
-          publish_branch: care-sbom
+          publish_branch: gh-pages

--- a/.github/workflows/fetch-sbom.yml
+++ b/.github/workflows/fetch-sbom.yml
@@ -4,9 +4,6 @@ on:
   schedule:
     - cron: '30 18 * * 6' # Runs every Sunday at midnight IST (18:30 UTC on Saturdays)
   workflow_dispatch:
-  push:
-    branches:
-      - main
 
 permissions:
   contents: write
@@ -20,37 +17,47 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Get latest release version for care repo
-        id: care_version
+      - name: Get latest release versions for care and care_fe
+        id: versions
         run: |
-          VERSION=$(curl -s https://api.github.com/repos/ohcnetwork/care/releases/latest | jq -r .tag_name)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          CARE_VERSION=$(curl -s https://api.github.com/repos/ohcnetwork/care/releases/latest | jq -r .tag_name)
+          CARE_FE_VERSION=$(curl -s https://api.github.com/repos/ohcnetwork/care_fe/releases/latest | jq -r .tag_name)
+          echo "CARE_VERSION=$CARE_VERSION" >> $GITHUB_ENV
+          echo "CARE_FE_VERSION=$CARE_FE_VERSION" >> $GITHUB_ENV
 
-      - name: Get latest release version for care_fe repo
-        id: care_fe_version
+      - name: Create SBOM directories for care and care_fe (if not exists)
         run: |
-          VERSION=$(curl -s https://api.github.com/repos/ohcnetwork/care_fe/releases/latest | jq -r .tag_name)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          if [ ! -d "care/${{ env.CARE_VERSION }}" ]; then
+            mkdir -p care/${{ env.CARE_VERSION }}
+          fi
+          if [ ! -d "care_fe/${{ env.CARE_FE_VERSION }}" ]; then
+            mkdir -p care_fe/${{ env.CARE_FE_VERSION }}
+          fi
 
-      - name: Check and create SBOM directories for care and care_fe
+      - name: Fetch SBOM data for care and care_fe (if not exists)
         run: |
-          for repo in "care" "care_fe"; do
-            if [ ! -d "$repo/${{ env.VERSION }}" ]; then
-              mkdir -p $repo/${{ env.VERSION }}
-              curl -H "Accept: application/vnd.github+json" \
-                   -H "X-GitHub-Api-Version: 2022-11-28" \
-                   https://api.github.com/repos/ohcnetwork/$repo/dependency-graph/sbom > $repo/${{ env.VERSION }}/sbom.json
-            else
-              echo "$repo/${{ env.VERSION }} already exists. Skipping SBOM fetch for $repo."
-            fi
-          done
+          if [ ! -f "care/${{ env.CARE_VERSION }}/sbom.json" ]; then
+            curl -H "Accept: application/vnd.github+json" \
+                 -H "X-GitHub-Api-Version: 2022-11-28" \
+                 https://api.github.com/repos/ohcnetwork/care/dependency-graph/sbom > care/${{ env.CARE_VERSION }}/sbom.json
+          else
+            echo "SBOM data for care version ${{ env.CARE_VERSION }} already exists, skipping fetch."
+          fi
+
+          if [ ! -f "care_fe/${{ env.CARE_FE_VERSION }}/sbom.json" ]; then
+            curl -H "Accept: application/vnd.github+json" \
+                 -H "X-GitHub-Api-Version: 2022-11-28" \
+                 https://api.github.com/repos/ohcnetwork/care_fe/dependency-graph/sbom > care_fe/${{ env.CARE_FE_VERSION }}/sbom.json
+          else
+            echo "SBOM data for care_fe version ${{ env.CARE_FE_VERSION }} already exists, skipping fetch."
+          fi
 
       - name: Commit and push changes
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
-          git add . 
-          git diff --exit-code || git commit -m "Update SBOM data for version ${{ env.VERSION }}"
+          git add .
+          git commit -m "Update SBOM data for care ${{ env.CARE_VERSION }} and care_fe ${{ env.CARE_FE_VERSION }}" || exit 0
           git push || exit 0
 
   deploy-sbom:
@@ -62,5 +69,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./ 
+          publish_dir: ./
           publish_branch: care-sbom

--- a/.github/workflows/fetch-sbom.yml
+++ b/.github/workflows/fetch-sbom.yml
@@ -61,8 +61,8 @@ jobs:
 
     steps:
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./
-          publish_branch: main
+          publish_branch: care-sbom

--- a/.github/workflows/fetch-sbom.yml
+++ b/.github/workflows/fetch-sbom.yml
@@ -65,6 +65,9 @@ jobs:
     needs: fetch-sbom
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Open Healthcare Network
+Copyright (c) 2025 Open Healthcare Network
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Weekly SBOM Update
 
-This repository uses a GitHub Actions workflow to fetch and update the Software Bill of Materials (SBOM) for `care` and `care_fe` every week, deploying the data to GitHub Pages.
+This repository uses a GitHub Actions workflow to fetch and update the Software Bill of Materials (SBOM) for `care` and `care_fe` every week on **Sunday**, deploying the data to GitHub Pages.
 
 The latest SBOM data is available at: [https://ohcnetwork.github.io/care_sbom/](https://ohcnetwork.github.io/care_sbom/)
+
+**NOTE:** To access SBOM data, navigate to `/care/{version}/sbom.json` (e.g., `/care/v3.0.0/sbom.json`)
 
 ## Workflow Overview
 
@@ -20,7 +22,6 @@ The workflow, defined in [`.github/workflows/fetch-sbom.yml`](.github/workflows/
 ## Workflow Triggers
 - **Scheduled:** Runs every Sunday at midnight IST (18:30 UTC Saturday)
 - **Manual Dispatch:** Can be triggered manually
-- **Push to `main` branch**
 
 ## Permissions
 - `contents: write` – Commit & push changes

--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# Weekly SBOM Update
+
+This repository uses a GitHub Actions workflow to fetch and update the Software Bill of Materials (SBOM) for `care` and `care_fe` every week, deploying the data to GitHub Pages.
+
+The latest SBOM data is available at: [https://ohcnetwork.github.io/care_sbom/](https://ohcnetwork.github.io/care_sbom/)
+
+## Workflow Overview
+
+The workflow, defined in [`.github/workflows/fetch-sbom.yml`](.github/workflows/fetch-sbom.yml), has two main jobs:
+
+### 1. `fetch-sbom` Job
+- **Checkout repository**
+- **Fetch latest release versions** of `care` and `care_fe` using the GitHub API
+- **Create SBOM directories** if they don’t exist and fetch SBOM data
+- **Commit & push changes** if updates are found
+
+### 2. `deploy-sbom` Job
+- Deploys SBOM data to GitHub Pages using `peaceiris/actions-gh-pages@v4`
+
+## Workflow Triggers
+- **Scheduled:** Runs every Sunday at midnight IST (18:30 UTC Saturday)
+- **Manual Dispatch:** Can be triggered manually
+- **Push to `main` branch**
+
+## Permissions
+- `contents: write` – Commit & push changes
+- `pages: write` – Deploy SBOM data
+
+## License
+This project is licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
Signed-off-by: Areeb Ahmed [hi@areeb.cloud](mailto:hi@areeb.cloud)  

- Fixes: #1
- Automates weekly SBOM updates for `care` and `care_fe`, deploying them to GitHub Pages every Sunday.

### **Checklist**:

- [x] Tested in my repo.

![image](https://github.com/user-attachments/assets/b5f70c60-1fcb-4394-a360-7c890b3638bd)
![image](https://github.com/user-attachments/assets/959ecd5b-85ee-4768-ad27-82c11ba29f80)

- [x] Ensured SBOM data is available on GitHub Pages.

![image](https://github.com/user-attachments/assets/532fb30c-90e7-49cc-9c25-84bc4a6ab070)


### **Instructions**:

1. **Set Workflow Permissions**: Go to Settings > Actions > Workflow permissions > Select "Read and write permissions."
2. **Enable GitHub Pages**: Go to Settings > Pages > Set source to GitHub Actions.