### PR TITLE
chore: filter out CI/CD dependencies from SBOM

### DIFF
--- a/.github/workflows/fetch-sbom.yml
+++ b/.github/workflows/fetch-sbom.yml
@@ -1,8 +1,6 @@
 name: Weekly SBOM Update
 
 on:
-  schedule:
-    - cron: '30 18 * * 6' # Runs every Sunday at midnight IST (18:30 UTC on Saturdays)
   workflow_dispatch:
 
 permissions:
@@ -35,9 +33,8 @@ jobs:
           FILTER_CICD="^actions/|codecov/|getsentry/|reproducible-containers/|leonsteinhaeuser/"
           FILTER_AWS="^aws-actions/|boto3|botocore|types-awscrt|mypy-boto3-s3"
           FILTER_DOCKER="^docker/"
-          FILTER_MISC="s3transfer|types-s3transfer"
 
-          FILTER_REGEX="($FILTER_CICD|$FILTER_AWS|$FILTER_DOCKER|$FILTER_MISC)"
+          FILTER_REGEX="($FILTER_CICD|$FILTER_AWS|$FILTER_DOCKER|${{ env.EXTRA_FILTERS }})"
 
           if [ ! -f "care/${{ env.CARE_VERSION }}/sbom.json" ]; then
             curl -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/fetch-sbom.yml
+++ b/.github/workflows/fetch-sbom.yml
@@ -32,10 +32,19 @@ jobs:
 
       - name: Fetch SBOM data for care and care_fe (if not exists)
         run: |
+          FILTER_CICD="^actions/|codecov/|getsentry/|reproducible-containers/|leonsteinhaeuser/"
+          FILTER_AWS="^aws-actions/|boto3|botocore|types-awscrt|mypy-boto3-s3"
+          FILTER_DOCKER="^docker/"
+          FILTER_MISC="s3transfer|types-s3transfer"
+
+          FILTER_REGEX="($FILTER_CICD|$FILTER_AWS|$FILTER_DOCKER|$FILTER_MISC)"
+
           if [ ! -f "care/${{ env.CARE_VERSION }}/sbom.json" ]; then
             curl -H "Accept: application/vnd.github+json" \
                  -H "X-GitHub-Api-Version: 2022-11-28" \
-                 https://api.github.com/repos/ohcnetwork/care/dependency-graph/sbom > care/${{ env.CARE_VERSION }}/sbom.json
+                 https://api.github.com/repos/ohcnetwork/care/dependency-graph/sbom | \
+            jq --arg regex "$FILTER_REGEX" 'del(.sbom.packages[] | select(.name | test($regex)))' \
+            > care/${{ env.CARE_VERSION }}/sbom.json
           else
             echo "SBOM data for care version ${{ env.CARE_VERSION }} already exists, skipping fetch."
           fi
@@ -43,7 +52,9 @@ jobs:
           if [ ! -f "care_fe/${{ env.CARE_FE_VERSION }}/sbom.json" ]; then
             curl -H "Accept: application/vnd.github+json" \
                  -H "X-GitHub-Api-Version: 2022-11-28" \
-                 https://api.github.com/repos/ohcnetwork/care_fe/dependency-graph/sbom > care_fe/${{ env.CARE_FE_VERSION }}/sbom.json
+                 https://api.github.com/repos/ohcnetwork/care_fe/dependency-graph/sbom | \
+            jq --arg regex "$FILTER_REGEX" 'del(.sbom.packages[] | select(.name | test($regex)))' \
+            > care_fe/${{ env.CARE_FE_VERSION }}/sbom.json
           else
             echo "SBOM data for care_fe version ${{ env.CARE_FE_VERSION }} already exists, skipping fetch."
           fi

--- a/.github/workflows/fetch-sbom.yml
+++ b/.github/workflows/fetch-sbom.yml
@@ -1,6 +1,8 @@
 name: Weekly SBOM Update
 
 on:
+  schedule:
+    - cron: '30 18 * * 6' # Runs every Sunday at midnight IST (18:30 UTC on Saturdays)
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Signed-off-by: Areeb Ahmed [hi@areeb.cloud](mailto:hi@areeb.cloud)  

- Fixes #4  
- Applied `jq` filtering to exclude non-runtime dependencies from SBOM.  

### **Usage**  
Go to **Settings > Secrets and variables > Actions**, then add **`EXTRA_FILTERS`** as a variable and set it to:  

```yaml
EXTRA_FILTERS="s3transfer|types-s3transfer"
```