### PR TITLE
fix: use vars instead of env

### DIFF
--- a/.github/workflows/fetch-sbom.yml
+++ b/.github/workflows/fetch-sbom.yml
@@ -36,7 +36,7 @@ jobs:
           FILTER_AWS="^aws-actions/|boto3|botocore|types-awscrt|mypy-boto3-s3"
           FILTER_DOCKER="^docker/"
 
-          FILTER_REGEX="($FILTER_CICD|$FILTER_AWS|$FILTER_DOCKER|${{ env.EXTRA_FILTERS }})"
+          FILTER_REGEX="($FILTER_CICD|$FILTER_AWS|$FILTER_DOCKER|${{ vars.EXTRA_FILTERS }})"
 
           if [ ! -f "care/${{ env.CARE_VERSION }}/sbom.json" ]; then
             curl -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
Signed-off-by: Areeb Ahmed [hi@areeb.cloud](mailto:hi@areeb.cloud)  

- Fixes #6 
- No need for env as extra filters don't contain sensitive data.

<img width="618" alt="{99DCAF3F-B688-41D1-9FAB-971659B60C49}" src="https://github.com/user-attachments/assets/26194520-d1b7-4026-a15c-7ccc784ccd8f" />

CC: @tellmeY18 