### PR TITLE
Update README to reflect sbom.yml workflow rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The latest SBOM data is available at: [https://sbom.ohc.network/](https://sbom.o
 
 ## Workflow Overview
 
-The workflow, defined in [`.github/workflows/fetch-sbom.yml`](.github/workflows/fetch-sbom.yml), has two main jobs:
+The workflow, defined in [`.github/workflows/sbom.yml`](.github/workflows/sbom.yml), has two main jobs:
 
 ### 1. `fetch-sbom` Job
 - **Checkout repository**


### PR DESCRIPTION
This PR updates the `README.md` to reflect the current GitHub Actions workflow filename (`sbom.yml`). 

The GitHub Actions workflow was renamed earlier, but the README was not updated accordingly. This caused a mismatch between the documentation and the actual workflow configuration, which could confuse contributors or users referencing the setup instructions.

With the proposed change, documentation now matches the current repository structure.